### PR TITLE
Fix combine serve return value

### DIFF
--- a/Team25Pat.pcsp
+++ b/Team25Pat.pcsp
@@ -21,6 +21,7 @@ var MTscore = 0;
 var KSscore = 0;
 var won = na;
 var ball = 9;
+var winningScore = 7;
 
 TieBreakGame = WhoServe1st; (MTServe [] KSServe);
 
@@ -87,13 +88,13 @@ S_SecondServeFrom8 = pcase {
 KS_ServeReturnFrom7 = pcase {                              
 			0: KServeReturn -> K_ServeReturnFrom7
 			34: SServeReturn -> S_ServeReturnFrom7
-			6: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if (MTscore == 7) {won = MT} else { turn = (turn+1)%4} } -> NextPt
+			0: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if (MTscore == winningScore) {won = MT} else { turn = (turn+1)%4} } -> NextPt
 };
 
 KS_ServeReturnFrom8 = pcase {                              
 			34: KServeReturn -> K_ServeReturnFrom8
 			0: SServeReturn -> S_ServeReturnFrom8
-			12: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if (MTscore == 7) {won = MT} else { turn = (turn+1)%4} } -> NextPt
+			0: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if (MTscore == winningScore) {won = MT} else { turn = (turn+1)%4} } -> NextPt
 };		
 
 // No data on case K Serve Return from 7
@@ -364,13 +365,13 @@ T_SecondServeFrom2 = pcase {
 MT_ServeReturnFrom1 = pcase {                              
 			0: MServeReturn -> M_ServeReturnFrom1
 			38: TServeReturn -> T_ServeReturnFrom1
-			7: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if (KSscore == 7) {won = KS} else { turn = (turn+1)%4} } -> NextPt
+			0: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if (KSscore == winningScore) {won = KS} else { turn = (turn+1)%4} } -> NextPt
 };
 
 MT_ServeReturnFrom2 = pcase {                              
 			40: MServeReturn -> M_ServeReturnFrom2
 			0: TServeReturn -> T_ServeReturnFrom2
-			4: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if (KSscore == 7) {won = KS} else { turn = (turn+1)%4} } -> NextPt
+			0: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if (KSscore == winningScore) {won = KS} else { turn = (turn+1)%4} } -> NextPt
 };
 
 M_ServeReturnFrom1 = pcase {                              

--- a/Team25Pat.pcsp
+++ b/Team25Pat.pcsp
@@ -88,7 +88,7 @@ S_SecondServeFrom8 = pcase {
 KS_ServeReturnFrom7 = pcase {                              
 			0: KServeReturn -> K_ServeReturnFrom7
 			34: SServeReturn -> S_ServeReturnFrom7
-			0: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if (MTscore == winningScore) {won = MT} else { turn = (turn+1)%4} } -> NextPt
+			2: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if (MTscore == winningScore) {won = MT} else { turn = (turn+1)%4} } -> NextPt
 };
 
 KS_ServeReturnFrom8 = pcase {                              
@@ -371,7 +371,7 @@ MT_ServeReturnFrom1 = pcase {
 MT_ServeReturnFrom2 = pcase {                              
 			40: MServeReturn -> M_ServeReturnFrom2
 			0: TServeReturn -> T_ServeReturnFrom2
-			0: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if (KSscore == winningScore) {won = KS} else { turn = (turn+1)%4} } -> NextPt
+			1: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if (KSscore == winningScore) {won = KS} else { turn = (turn+1)%4} } -> NextPt
 };
 
 M_ServeReturnFrom1 = pcase {                              


### PR DESCRIPTION
Similarly, the error rates for pair ServeReturns are already captured in individual ServeReturns (the receiver is fixed given the position). Hence, the error rate should not be present in the combine cases.

Somehow, this raises the winning probability (K&S) to >50%
<img width="600" alt="image" src="https://user-images.githubusercontent.com/19379090/195123064-94d6778e-02d0-47b4-af41-2da53d56087a.png">
