### PR TITLE
Change scoring system

### DIFF
--- a/PointToGame.pcsp
+++ b/PointToGame.pcsp
@@ -1,4 +1,4 @@
-﻿// Pair 1: McNally and Townsend
+// Pair 1: McNally and Townsend
 //
 // ------+------
 // |  1  |  2  |
@@ -21,7 +21,8 @@ var MTscore = 0;
 var KSscore = 0;
 var won = na;
 var ball = 9;
-var winningScore = 7;
+var winningScore = 4;
+var pointLead = 2;
 
 // Variations of Game based on who is serving
 Game_KServing = DecideServer_K; StartingServe;
@@ -54,12 +55,12 @@ K_FirstServeFrom8 = pcase {
 
 K_SecondServeFrom7 = pcase {                              
 			7: ServeToPosition2{ball = 2} -> MT_ServeReturnFrom2
-			0: ServeError{ball = 9} -> KSDoubleFault{MTscore++; if (MTscore == winningScore) {won = MT}} -> NextPt
+			0: ServeError{ball = 9} -> KSDoubleFault{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}} -> NextPt
 };
 
 K_SecondServeFrom8 = pcase {                              
 			10: ServeToPosition1{ball = 1} -> MT_ServeReturnFrom1
-			1: ServeError{ball = 9} -> KSDoubleFault{MTscore++; if (MTscore == winningScore) {won = MT}} -> NextPt
+			1: ServeError{ball = 9} -> KSDoubleFault{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}} -> NextPt
 };		
 
 S_FirstServeFrom7 = pcase {                              
@@ -74,25 +75,25 @@ S_FirstServeFrom8 = pcase {
 
 S_SecondServeFrom7 = pcase {                              
 			7: ServeToPosition2{ball = 2} -> MT_ServeReturnFrom2
-			2: ServeError{ball = 9} -> KSDoubleFault{MTscore++; if (MTscore == winningScore) {won = MT}} -> NextPt
+			2: ServeError{ball = 9} -> KSDoubleFault{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}} -> NextPt
 };
 
 S_SecondServeFrom8 = pcase {                              
 			7: ServeToPosition1{ball = 1} -> MT_ServeReturnFrom1
-			2: ServeError{ball = 9} -> KSDoubleFault{MTscore++; if (MTscore == winningScore) {won = MT}} -> NextPt
+			2: ServeError{ball = 9} -> KSDoubleFault{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}} -> NextPt
 };
 
 // KS - Serve Return
 KS_ServeReturnFrom7 = pcase {                              
 			0: KServeReturn -> K_ServeReturnFrom7
 			34: SServeReturn -> S_ServeReturnFrom7
-			2: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if (MTscore == winningScore) {won = MT}} -> NextPt
+			2: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}} -> NextPt
 };
 
 KS_ServeReturnFrom8 = pcase {                              
 			34: KServeReturn -> K_ServeReturnFrom8
 			0: SServeReturn -> S_ServeReturnFrom8
-			0: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if (MTscore == winningScore) {won = MT}} -> NextPt
+			0: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}} -> NextPt
 };		
 
 // No data on case K Serve Return from 7
@@ -105,9 +106,9 @@ K_ServeReturnFrom7 = pcase {
 			0: FH_ServeReturnToPosition2{ball = 2} -> MT_NormalReturnFrom2
 			0: FH_ServeReturnToPosition3{ball = 3} -> MT_NormalReturnFrom3
 			0: FH_ServeReturnToPosition4{ball = 4} -> MT_NormalReturnFrom4                         
-			0: BH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore == winningScore) {won = MT}}
+			0: BH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
 				-> NextPt
-			0: FH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore == winningScore) {won = MT}}
+			0: FH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
 				-> NextPt
 };	
 
@@ -120,9 +121,9 @@ K_ServeReturnFrom8 = pcase {
 			4: FH_ServeReturnToPosition2{ball = 2} -> MT_NormalReturnFrom2
 			1: FH_ServeReturnToPosition3{ball = 3} -> MT_NormalReturnFrom3
 			9: FH_ServeReturnToPosition4{ball = 4} -> MT_NormalReturnFrom4                         
-			7: BH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore == winningScore) {won = MT}}
+			7: BH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
 				-> NextPt
-			5: FH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore == winningScore) {won = MT}}
+			5: FH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
 				-> NextPt
 };	
 
@@ -135,9 +136,9 @@ S_ServeReturnFrom7 = pcase {
 			10: FH_ServeReturnToPosition2{ball = 2} -> MT_NormalReturnFrom2
 			7: FH_ServeReturnToPosition3{ball = 3} -> MT_NormalReturnFrom3
 			3: FH_ServeReturnToPosition4{ball = 4} -> MT_NormalReturnFrom4                         
-			1: BH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore == winningScore) {won = MT}}
+			1: BH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
 				-> NextPt
-			5: FH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore == winningScore) {won = MT}}
+			5: FH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
 				-> NextPt
 };	
 
@@ -151,9 +152,9 @@ S_ServeReturnFrom8 = pcase {
 			0: FH_ServeReturnToPosition2{ball = 2} -> MT_NormalReturnFrom2
 			0: FH_ServeReturnToPosition3{ball = 3} -> MT_NormalReturnFrom3
 			0: FH_ServeReturnToPosition4{ball = 4} -> MT_NormalReturnFrom4                         
-			0: BH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore == winningScore) {won = MT}}
+			0: BH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
 				-> NextPt
-			0: FH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore == winningScore) {won = MT}}
+			0: FH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
 				-> NextPt
 };	
 
@@ -161,25 +162,25 @@ S_ServeReturnFrom8 = pcase {
 KS_NormalReturnFrom5 = pcase {                              
 			4: KNormalReturn -> K_NormalReturnFrom5
 			28: SNormalReturn -> S_NormalReturnFrom5
-			7: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if (MTscore == winningScore) {won = MT}} -> NextPt
+			7: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}} -> NextPt
 };
 
 KS_NormalReturnFrom6 = pcase {                              
 			21: KNormalReturn -> K_NormalReturnFrom6
 			10: SNormalReturn -> S_NormalReturnFrom6
-			9: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if (MTscore == winningScore) {won = MT}} -> NextPt
+			9: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}} -> NextPt
 };
 
 KS_NormalReturnFrom7 = pcase {                              
 			12: KNormalReturn -> K_NormalReturnFrom7
 			35: SNormalReturn -> S_NormalReturnFrom7
-			7: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if (MTscore == winningScore) {won = MT}} -> NextPt
+			7: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}} -> NextPt
 };
 
 KS_NormalReturnFrom8 = pcase {                              
 			73: KNormalReturn -> K_NormalReturnFrom8
 			14: SNormalReturn -> S_NormalReturnFrom8
-			4: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if (MTscore == winningScore) {won = MT}} -> NextPt
+			4: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}} -> NextPt
 };
 
 K_NormalReturnFrom5 = pcase {
@@ -191,9 +192,9 @@ K_NormalReturnFrom5 = pcase {
 			1: FH_NormalReturnToPosition2{ball = 2} -> MT_NormalReturnFrom2
 			1: FH_NormalReturnToPosition3{ball = 3} -> MT_NormalReturnFrom3
 			1: FH_NormalReturnToPosition4{ball = 4} -> MT_NormalReturnFrom4                         
-			1: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore == winningScore) {won = MT}}
+			1: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
 				-> NextPt
-			0: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore == winningScore) {won = MT}}
+			0: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
 				-> NextPt
 };	
 
@@ -206,9 +207,9 @@ K_NormalReturnFrom6 = pcase {
 			2: FH_NormalReturnToPosition2{ball = 2} -> MT_NormalReturnFrom2
 			5: FH_NormalReturnToPosition3{ball = 3} -> MT_NormalReturnFrom3
 			2: FH_NormalReturnToPosition4{ball = 4} -> MT_NormalReturnFrom4                         
-			1: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore == winningScore) {won = MT}}
+			1: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
 				-> NextPt
-			2: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore == winningScore) {won = MT}}
+			2: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
 				-> NextPt
 };	
 
@@ -221,9 +222,9 @@ K_NormalReturnFrom7 = pcase {
 			1: FH_NormalReturnToPosition2{ball = 2} -> MT_NormalReturnFrom2
 			2: FH_NormalReturnToPosition3{ball = 3} -> MT_NormalReturnFrom3
 			2: FH_NormalReturnToPosition4{ball = 4} -> MT_NormalReturnFrom4                         
-			0: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore == winningScore) {won = MT}}
+			0: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
 				-> NextPt
-			3: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore == winningScore) {won = MT}}
+			3: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
 				-> NextPt
 };	
 
@@ -236,9 +237,9 @@ K_NormalReturnFrom8 = pcase {
 			12: FH_NormalReturnToPosition2{ball = 2} -> MT_NormalReturnFrom2
 			13: FH_NormalReturnToPosition3{ball = 3} -> MT_NormalReturnFrom3
 			15: FH_NormalReturnToPosition4{ball = 4} -> MT_NormalReturnFrom4                         
-			5: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore == winningScore) {won = MT}}
+			5: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
 				-> NextPt
-			10: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore == winningScore) {won = MT}}
+			10: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
 				-> NextPt
 };	
 
@@ -251,9 +252,9 @@ S_NormalReturnFrom5 = pcase {
 			2: FH_NormalReturnToPosition2{ball = 2} -> MT_NormalReturnFrom2
 			3: FH_NormalReturnToPosition3{ball = 3} -> MT_NormalReturnFrom3
 			3: FH_NormalReturnToPosition4{ball = 4} -> MT_NormalReturnFrom4                         
-			1: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore == winningScore) {won = MT}}
+			1: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
 				-> NextPt
-			1: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore == winningScore) {won = MT}}
+			1: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
 				-> NextPt
 };	
 
@@ -266,9 +267,9 @@ S_NormalReturnFrom6 = pcase {
 			1: FH_NormalReturnToPosition2{ball = 2} -> MT_NormalReturnFrom2
 			1: FH_NormalReturnToPosition3{ball = 3} -> MT_NormalReturnFrom3
 			4: FH_NormalReturnToPosition4{ball = 4} -> MT_NormalReturnFrom4                         
-			1: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore == winningScore) {won = MT}}
+			1: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
 				-> NextPt
-			2: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore == winningScore) {won = MT}}
+			2: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
 				-> NextPt
 };	
 
@@ -281,9 +282,9 @@ S_NormalReturnFrom7 = pcase {
 			2: FH_NormalReturnToPosition2{ball = 2} -> MT_NormalReturnFrom2
 			5: FH_NormalReturnToPosition3{ball = 3} -> MT_NormalReturnFrom3
 			2: FH_NormalReturnToPosition4{ball = 4} -> MT_NormalReturnFrom4                         
-			5: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore == winningScore) {won = MT}}
+			5: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
 				-> NextPt
-			2: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore == winningScore) {won = MT}}
+			2: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
 				-> NextPt
 };	
 
@@ -296,9 +297,9 @@ S_NormalReturnFrom8 = pcase {
 			0: FH_NormalReturnToPosition2{ball = 2} -> MT_NormalReturnFrom2
 			3: FH_NormalReturnToPosition3{ball = 3} -> MT_NormalReturnFrom3
 			4: FH_NormalReturnToPosition4{ball = 4} -> MT_NormalReturnFrom4                         
-			1: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore == winningScore) {won = MT}}
+			1: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
 				-> NextPt
-			3: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore == winningScore) {won = MT}}
+			3: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
 				-> NextPt
 };	
 
@@ -329,35 +330,35 @@ T_FirstServeFrom2 = pcase {
 		
 M_SecondServeFrom1 = pcase {                              
 			6: ServeToPosition8{ball = 8} -> KS_ServeReturnFrom8
-			2: ServeError{ball = 9} -> MTDoubleFault{KSscore++; if (KSscore == winningScore) {won = KS}} -> NextPt
+			2: ServeError{ball = 9} -> MTDoubleFault{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}} -> NextPt
 };
 
 M_SecondServeFrom2 = pcase {                              
 			6: ServeToPosition7{ball = 7} -> KS_ServeReturnFrom7
-			1: ServeError{ball = 9} -> MTDoubleFault{KSscore++; if (KSscore == winningScore) {won = KS}} -> NextPt
+			1: ServeError{ball = 9} -> MTDoubleFault{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}} -> NextPt
 };
 			
 T_SecondServeFrom1 = pcase {                              
 			6: ServeToPosition8{ball = 8} -> KS_ServeReturnFrom8
-			0: ServeError{ball = 9} -> MTDoubleFault{KSscore++; if (KSscore == winningScore) {won = KS}} -> NextPt
+			0: ServeError{ball = 9} -> MTDoubleFault{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}} -> NextPt
 };
 
 T_SecondServeFrom2 = pcase {                              
 			7: ServeToPosition7{ball = 7} -> KS_ServeReturnFrom7
-			0: ServeError{ball = 9} -> MTDoubleFault{KSscore++; if (KSscore == winningScore) {won = KS}} -> NextPt
+			0: ServeError{ball = 9} -> MTDoubleFault{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}} -> NextPt
 };
 
 //MT - Serve Return
 MT_ServeReturnFrom1 = pcase {                              
 			0: MServeReturn -> M_ServeReturnFrom1
 			38: TServeReturn -> T_ServeReturnFrom1
-			0: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if (KSscore == winningScore) {won = KS}} -> NextPt
+			0: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}} -> NextPt
 };
 
 MT_ServeReturnFrom2 = pcase {                              
 			40: MServeReturn -> M_ServeReturnFrom2
 			0: TServeReturn -> T_ServeReturnFrom2
-			1: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if (KSscore == winningScore) {won = KS}} -> NextPt
+			1: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}} -> NextPt
 };
 
 M_ServeReturnFrom1 = pcase {                              
@@ -369,9 +370,9 @@ M_ServeReturnFrom1 = pcase {
 			0: FH_ServeReturnToPosition6{ball = 6} -> KS_NormalReturnFrom6
 			0: FH_ServeReturnToPosition7{ball = 7} -> KS_NormalReturnFrom7
 			0: FH_ServeReturnToPosition8{ball = 8} -> KS_NormalReturnFrom8
-			0: BH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if (KSscore == winningScore) {won = KS} 
+			0: BH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS} 
       		                                                        }-> NextPt
-      		0: FH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if (KSscore == winningScore) {won = KS} 
+      		0: FH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS} 
       		                                                        }-> NextPt
 };
 
@@ -384,9 +385,9 @@ M_ServeReturnFrom2 = pcase {
 			6: FH_ServeReturnToPosition6{ball = 6} -> KS_NormalReturnFrom6
 			2: FH_ServeReturnToPosition7{ball = 7} -> KS_NormalReturnFrom7
 			7: FH_ServeReturnToPosition8{ball = 8} -> KS_NormalReturnFrom8
-			2: BH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if (KSscore == winningScore) {won = KS} 
+			2: BH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS} 
       		                                                        }-> NextPt
-      		2: FH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if (KSscore == winningScore) {won = KS} 
+      		2: FH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS} 
       		                                                        }-> NextPt
 };
 
@@ -399,9 +400,9 @@ T_ServeReturnFrom1 = pcase {
 			1: FH_ServeReturnToPosition6{ball = 6} -> KS_NormalReturnFrom6
 			3: FH_ServeReturnToPosition7{ball = 7} -> KS_NormalReturnFrom7
 			6: FH_ServeReturnToPosition8{ball = 8} -> KS_NormalReturnFrom8
-			4: BH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if (KSscore == winningScore) {won = KS} 
+			4: BH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS} 
       		                                                        }-> NextPt
-      		3: FH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if (KSscore == winningScore) {won = MT} 
+      		3: FH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = MT} 
       		                                                        }-> NextPt
 };
 
@@ -414,9 +415,9 @@ T_ServeReturnFrom2 = pcase {
 			0: FH_ServeReturnToPosition6{ball = 6} -> KS_NormalReturnFrom6
 			0: FH_ServeReturnToPosition7{ball = 7} -> KS_NormalReturnFrom7
 			0: FH_ServeReturnToPosition8{ball = 8} -> KS_NormalReturnFrom8
-			0: FH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if (KSscore == winningScore) {won = KS} 
+			0: FH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS} 
       		                                                        }-> NextPt
-      		0: BH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if (KSscore == winningScore) {won = KS} 
+      		0: BH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS} 
       		                                                        }-> NextPt
 };
 
@@ -424,28 +425,28 @@ T_ServeReturnFrom2 = pcase {
 MT_NormalReturnFrom1 = pcase {
 			13: MNormalReturn -> M_NormalReturnFrom1
 			24: TNormalReturn -> T_NormalReturnFrom1
-			8: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if (KSscore == winningScore) {won = KS} 
+			8: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS} 
       		                                                        }-> NextPt
 };
 
 MT_NormalReturnFrom2 = pcase {
 			31: MNormalReturn -> M_NormalReturnFrom2
 			8: TNormalReturn -> T_NormalReturnFrom2
-			7: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if (KSscore == winningScore) {won = KS} 
+			7: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS} 
       		                                                        }-> NextPt
 };
 
 MT_NormalReturnFrom3 = pcase {
 			20: MNormalReturn -> M_NormalReturnFrom3
 			24: TNormalReturn -> T_NormalReturnFrom3
-			16: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if (KSscore == winningScore) {won = KS}     		                                                        
+			16: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}     		                                                        
 																	}-> NextPt
 };
 
 MT_NormalReturnFrom4 = pcase {
 			41: MNormalReturn -> M_NormalReturnFrom4
 			19: TNormalReturn -> T_NormalReturnFrom4
-			11: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if (KSscore == winningScore) {won = KS} 
+			11: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS} 
       		                                                        }-> NextPt
 };		
 
@@ -458,9 +459,9 @@ M_NormalReturnFrom1 = pcase {
 			0: FH_NormalReturnToPosition6{ball = 6} -> KS_NormalReturnFrom6
 			3: FH_NormalReturnToPosition7{ball = 7} -> KS_NormalReturnFrom7
 			7: FH_NormalReturnToPosition8{ball = 8} -> KS_NormalReturnFrom8                         
-			0: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore == winningScore) {won = KS}}
+			0: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
 				-> NextPt
-			1: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore == winningScore) {won = KS}}
+			1: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
 				-> NextPt
 };	
 
@@ -473,9 +474,9 @@ M_NormalReturnFrom2 = pcase {
 			4: FH_NormalReturnToPosition6{ball = 6} -> KS_NormalReturnFrom6
 			1: FH_NormalReturnToPosition7{ball = 7} -> KS_NormalReturnFrom7
 			14: FH_NormalReturnToPosition8{ball = 8} -> KS_NormalReturnFrom8                         
-			3: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore == winningScore) {won = KS}}
+			3: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
 				-> NextPt
-			2: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore == winningScore) {won = KS}}
+			2: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
 				-> NextPt
 };
 
@@ -488,9 +489,9 @@ M_NormalReturnFrom3 = pcase {
 			4: FH_NormalReturnToPosition6{ball = 6} -> KS_NormalReturnFrom6
 			3: FH_NormalReturnToPosition7{ball = 7} -> KS_NormalReturnFrom7
 			8: FH_NormalReturnToPosition8{ball = 8} -> KS_NormalReturnFrom8                         
-			0: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore == winningScore) {won = KS}}
+			0: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
 				-> NextPt
-			4: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore == winningScore) {won = KS}}
+			4: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
 				-> NextPt
 };	
 
@@ -503,9 +504,9 @@ M_NormalReturnFrom4 = pcase {
 			2: FH_NormalReturnToPosition6{ball = 6} -> KS_NormalReturnFrom6
 			7: FH_NormalReturnToPosition7{ball = 7} -> KS_NormalReturnFrom7
 			6: FH_NormalReturnToPosition8{ball = 8} -> KS_NormalReturnFrom8                         
-			7: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore == winningScore) {won = KS}}
+			7: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
 				-> NextPt
-			0: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore == winningScore) {won = KS}}
+			0: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
 				-> NextPt
 };					
 
@@ -518,9 +519,9 @@ T_NormalReturnFrom1 = pcase {
 			1: FH_NormalReturnToPosition6{ball = 6} -> KS_NormalReturnFrom6
 			0: FH_NormalReturnToPosition7{ball = 7} -> KS_NormalReturnFrom7
 			6: FH_NormalReturnToPosition8{ball = 8} -> KS_NormalReturnFrom8                         
-			2: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore == winningScore) {won = KS}}
+			2: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
 				-> NextPt
-			3: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore == winningScore) {won = KS}}
+			3: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
 				-> NextPt
 };
 
@@ -533,9 +534,9 @@ T_NormalReturnFrom2 = pcase {
 			0: FH_NormalReturnToPosition6{ball = 6} -> KS_NormalReturnFrom6
 			6: FH_NormalReturnToPosition7{ball = 7} -> KS_NormalReturnFrom7
 			1: FH_NormalReturnToPosition8{ball = 8} -> KS_NormalReturnFrom8                         
-			1: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore == winningScore) {won = KS}}
+			1: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
 				-> NextPt
-			3: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore == winningScore) {won = KS}}
+			3: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
 				-> NextPt
 };
 
@@ -548,9 +549,9 @@ T_NormalReturnFrom3 = pcase {
 			3: FH_NormalReturnToPosition6{ball = 6} -> KS_NormalReturnFrom6
 			3: FH_NormalReturnToPosition7{ball = 7} -> KS_NormalReturnFrom7
 			6: FH_NormalReturnToPosition8{ball = 8} -> KS_NormalReturnFrom8                         
-			7: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore == winningScore) {won = KS}}
+			7: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
 				-> NextPt
-			6: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore == winningScore) {won = KS}}
+			6: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
 				-> NextPt
 };			
 		
@@ -563,9 +564,9 @@ T_NormalReturnFrom4 = pcase {
 			3: FH_NormalReturnToPosition6{ball = 6} -> KS_NormalReturnFrom6
 			3: FH_NormalReturnToPosition7{ball = 7} -> KS_NormalReturnFrom7
 			2: FH_NormalReturnToPosition8{ball = 8} -> KS_NormalReturnFrom8                         
-			1: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore == winningScore) {won = KS}}
+			1: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
 				-> NextPt
-			1: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore == winningScore) {won = KS}}
+			1: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
 				-> NextPt
 };
 

--- a/PointToGame.pcsp
+++ b/PointToGame.pcsp
@@ -22,6 +22,7 @@ var KSscore = 0;
 var won = na;
 var ball = 9;
 var winningScore = 4;
+var scoreCap = 10;
 var pointLead = 2;
 
 // Variations of Game based on who is serving
@@ -55,12 +56,12 @@ K_FirstServeFrom8 = pcase {
 
 K_SecondServeFrom7 = pcase {                              
 			7: ServeToPosition2{ball = 2} -> MT_ServeReturnFrom2
-			0: ServeError{ball = 9} -> KSDoubleFault{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}} -> NextPt
+			0: ServeError{ball = 9} -> KSDoubleFault{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}} -> NextPt
 };
 
 K_SecondServeFrom8 = pcase {                              
 			10: ServeToPosition1{ball = 1} -> MT_ServeReturnFrom1
-			1: ServeError{ball = 9} -> KSDoubleFault{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}} -> NextPt
+			1: ServeError{ball = 9} -> KSDoubleFault{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}} -> NextPt
 };		
 
 S_FirstServeFrom7 = pcase {                              
@@ -75,25 +76,25 @@ S_FirstServeFrom8 = pcase {
 
 S_SecondServeFrom7 = pcase {                              
 			7: ServeToPosition2{ball = 2} -> MT_ServeReturnFrom2
-			2: ServeError{ball = 9} -> KSDoubleFault{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}} -> NextPt
+			2: ServeError{ball = 9} -> KSDoubleFault{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}} -> NextPt
 };
 
 S_SecondServeFrom8 = pcase {                              
 			7: ServeToPosition1{ball = 1} -> MT_ServeReturnFrom1
-			2: ServeError{ball = 9} -> KSDoubleFault{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}} -> NextPt
+			2: ServeError{ball = 9} -> KSDoubleFault{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}} -> NextPt
 };
 
 // KS - Serve Return
 KS_ServeReturnFrom7 = pcase {                              
 			0: KServeReturn -> K_ServeReturnFrom7
 			34: SServeReturn -> S_ServeReturnFrom7
-			2: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}} -> NextPt
+			2: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}} -> NextPt
 };
 
 KS_ServeReturnFrom8 = pcase {                              
 			34: KServeReturn -> K_ServeReturnFrom8
 			0: SServeReturn -> S_ServeReturnFrom8
-			0: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}} -> NextPt
+			0: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}} -> NextPt
 };		
 
 // No data on case K Serve Return from 7
@@ -106,9 +107,9 @@ K_ServeReturnFrom7 = pcase {
 			0: FH_ServeReturnToPosition2{ball = 2} -> MT_NormalReturnFrom2
 			0: FH_ServeReturnToPosition3{ball = 3} -> MT_NormalReturnFrom3
 			0: FH_ServeReturnToPosition4{ball = 4} -> MT_NormalReturnFrom4                         
-			0: BH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
+			0: BH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}}
 				-> NextPt
-			0: FH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
+			0: FH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}}
 				-> NextPt
 };	
 
@@ -121,9 +122,9 @@ K_ServeReturnFrom8 = pcase {
 			4: FH_ServeReturnToPosition2{ball = 2} -> MT_NormalReturnFrom2
 			1: FH_ServeReturnToPosition3{ball = 3} -> MT_NormalReturnFrom3
 			9: FH_ServeReturnToPosition4{ball = 4} -> MT_NormalReturnFrom4                         
-			7: BH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
+			7: BH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}}
 				-> NextPt
-			5: FH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
+			5: FH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}}
 				-> NextPt
 };	
 
@@ -136,9 +137,9 @@ S_ServeReturnFrom7 = pcase {
 			10: FH_ServeReturnToPosition2{ball = 2} -> MT_NormalReturnFrom2
 			7: FH_ServeReturnToPosition3{ball = 3} -> MT_NormalReturnFrom3
 			3: FH_ServeReturnToPosition4{ball = 4} -> MT_NormalReturnFrom4                         
-			1: BH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
+			1: BH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}}
 				-> NextPt
-			5: FH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
+			5: FH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}}
 				-> NextPt
 };	
 
@@ -152,9 +153,9 @@ S_ServeReturnFrom8 = pcase {
 			0: FH_ServeReturnToPosition2{ball = 2} -> MT_NormalReturnFrom2
 			0: FH_ServeReturnToPosition3{ball = 3} -> MT_NormalReturnFrom3
 			0: FH_ServeReturnToPosition4{ball = 4} -> MT_NormalReturnFrom4                         
-			0: BH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
+			0: BH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}}
 				-> NextPt
-			0: FH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
+			0: FH_ServeReturn_Out{ball = 9} -> KSOut{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}}
 				-> NextPt
 };	
 
@@ -162,25 +163,25 @@ S_ServeReturnFrom8 = pcase {
 KS_NormalReturnFrom5 = pcase {                              
 			4: KNormalReturn -> K_NormalReturnFrom5
 			28: SNormalReturn -> S_NormalReturnFrom5
-			7: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}} -> NextPt
+			7: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}} -> NextPt
 };
 
 KS_NormalReturnFrom6 = pcase {                              
 			21: KNormalReturn -> K_NormalReturnFrom6
 			10: SNormalReturn -> S_NormalReturnFrom6
-			9: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}} -> NextPt
+			9: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}} -> NextPt
 };
 
 KS_NormalReturnFrom7 = pcase {                              
 			12: KNormalReturn -> K_NormalReturnFrom7
 			35: SNormalReturn -> S_NormalReturnFrom7
-			7: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}} -> NextPt
+			7: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}} -> NextPt
 };
 
 KS_NormalReturnFrom8 = pcase {                              
 			73: KNormalReturn -> K_NormalReturnFrom8
 			14: SNormalReturn -> S_NormalReturnFrom8
-			4: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}} -> NextPt
+			4: FailToReturn{ball = 9} -> MTWinPoint{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}} -> NextPt
 };
 
 K_NormalReturnFrom5 = pcase {
@@ -192,9 +193,9 @@ K_NormalReturnFrom5 = pcase {
 			1: FH_NormalReturnToPosition2{ball = 2} -> MT_NormalReturnFrom2
 			1: FH_NormalReturnToPosition3{ball = 3} -> MT_NormalReturnFrom3
 			1: FH_NormalReturnToPosition4{ball = 4} -> MT_NormalReturnFrom4                         
-			1: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
+			1: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}}
 				-> NextPt
-			0: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
+			0: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}}
 				-> NextPt
 };	
 
@@ -207,9 +208,9 @@ K_NormalReturnFrom6 = pcase {
 			2: FH_NormalReturnToPosition2{ball = 2} -> MT_NormalReturnFrom2
 			5: FH_NormalReturnToPosition3{ball = 3} -> MT_NormalReturnFrom3
 			2: FH_NormalReturnToPosition4{ball = 4} -> MT_NormalReturnFrom4                         
-			1: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
+			1: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}}
 				-> NextPt
-			2: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
+			2: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}}
 				-> NextPt
 };	
 
@@ -222,9 +223,9 @@ K_NormalReturnFrom7 = pcase {
 			1: FH_NormalReturnToPosition2{ball = 2} -> MT_NormalReturnFrom2
 			2: FH_NormalReturnToPosition3{ball = 3} -> MT_NormalReturnFrom3
 			2: FH_NormalReturnToPosition4{ball = 4} -> MT_NormalReturnFrom4                         
-			0: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
+			0: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}}
 				-> NextPt
-			3: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
+			3: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}}
 				-> NextPt
 };	
 
@@ -237,9 +238,9 @@ K_NormalReturnFrom8 = pcase {
 			12: FH_NormalReturnToPosition2{ball = 2} -> MT_NormalReturnFrom2
 			13: FH_NormalReturnToPosition3{ball = 3} -> MT_NormalReturnFrom3
 			15: FH_NormalReturnToPosition4{ball = 4} -> MT_NormalReturnFrom4                         
-			5: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
+			5: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}}
 				-> NextPt
-			10: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
+			10: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}}
 				-> NextPt
 };	
 
@@ -252,9 +253,9 @@ S_NormalReturnFrom5 = pcase {
 			2: FH_NormalReturnToPosition2{ball = 2} -> MT_NormalReturnFrom2
 			3: FH_NormalReturnToPosition3{ball = 3} -> MT_NormalReturnFrom3
 			3: FH_NormalReturnToPosition4{ball = 4} -> MT_NormalReturnFrom4                         
-			1: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
+			1: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}}
 				-> NextPt
-			1: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
+			1: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}}
 				-> NextPt
 };	
 
@@ -267,9 +268,9 @@ S_NormalReturnFrom6 = pcase {
 			1: FH_NormalReturnToPosition2{ball = 2} -> MT_NormalReturnFrom2
 			1: FH_NormalReturnToPosition3{ball = 3} -> MT_NormalReturnFrom3
 			4: FH_NormalReturnToPosition4{ball = 4} -> MT_NormalReturnFrom4                         
-			1: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
+			1: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}}
 				-> NextPt
-			2: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
+			2: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}}
 				-> NextPt
 };	
 
@@ -282,9 +283,9 @@ S_NormalReturnFrom7 = pcase {
 			2: FH_NormalReturnToPosition2{ball = 2} -> MT_NormalReturnFrom2
 			5: FH_NormalReturnToPosition3{ball = 3} -> MT_NormalReturnFrom3
 			2: FH_NormalReturnToPosition4{ball = 4} -> MT_NormalReturnFrom4                         
-			5: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
+			5: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}}
 				-> NextPt
-			2: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
+			2: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}}
 				-> NextPt
 };	
 
@@ -297,9 +298,9 @@ S_NormalReturnFrom8 = pcase {
 			0: FH_NormalReturnToPosition2{ball = 2} -> MT_NormalReturnFrom2
 			3: FH_NormalReturnToPosition3{ball = 3} -> MT_NormalReturnFrom3
 			4: FH_NormalReturnToPosition4{ball = 4} -> MT_NormalReturnFrom4                         
-			1: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
+			1: BH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}}
 				-> NextPt
-			3: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if (MTscore >= winningScore && MTscore >= (KSscore + pointLead)) {won = MT}}
+			3: FH_NormalReturn_Out{ball = 9} -> KSOut{MTscore++; if ((MTscore >= winningScore && MTscore >= (KSscore + pointLead)) || (MTscore == scoreCap)) {won = MT}}
 				-> NextPt
 };	
 
@@ -330,35 +331,35 @@ T_FirstServeFrom2 = pcase {
 		
 M_SecondServeFrom1 = pcase {                              
 			6: ServeToPosition8{ball = 8} -> KS_ServeReturnFrom8
-			2: ServeError{ball = 9} -> MTDoubleFault{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}} -> NextPt
+			2: ServeError{ball = 9} -> MTDoubleFault{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS}} -> NextPt
 };
 
 M_SecondServeFrom2 = pcase {                              
 			6: ServeToPosition7{ball = 7} -> KS_ServeReturnFrom7
-			1: ServeError{ball = 9} -> MTDoubleFault{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}} -> NextPt
+			1: ServeError{ball = 9} -> MTDoubleFault{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS}} -> NextPt
 };
 			
 T_SecondServeFrom1 = pcase {                              
 			6: ServeToPosition8{ball = 8} -> KS_ServeReturnFrom8
-			0: ServeError{ball = 9} -> MTDoubleFault{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}} -> NextPt
+			0: ServeError{ball = 9} -> MTDoubleFault{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS}} -> NextPt
 };
 
 T_SecondServeFrom2 = pcase {                              
 			7: ServeToPosition7{ball = 7} -> KS_ServeReturnFrom7
-			0: ServeError{ball = 9} -> MTDoubleFault{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}} -> NextPt
+			0: ServeError{ball = 9} -> MTDoubleFault{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS}} -> NextPt
 };
 
 //MT - Serve Return
 MT_ServeReturnFrom1 = pcase {                              
 			0: MServeReturn -> M_ServeReturnFrom1
 			38: TServeReturn -> T_ServeReturnFrom1
-			0: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}} -> NextPt
+			0: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS}} -> NextPt
 };
 
 MT_ServeReturnFrom2 = pcase {                              
 			40: MServeReturn -> M_ServeReturnFrom2
 			0: TServeReturn -> T_ServeReturnFrom2
-			1: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}} -> NextPt
+			1: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS}} -> NextPt
 };
 
 M_ServeReturnFrom1 = pcase {                              
@@ -370,9 +371,9 @@ M_ServeReturnFrom1 = pcase {
 			0: FH_ServeReturnToPosition6{ball = 6} -> KS_NormalReturnFrom6
 			0: FH_ServeReturnToPosition7{ball = 7} -> KS_NormalReturnFrom7
 			0: FH_ServeReturnToPosition8{ball = 8} -> KS_NormalReturnFrom8
-			0: BH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS} 
+			0: BH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS} 
       		                                                        }-> NextPt
-      		0: FH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS} 
+      		0: FH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS} 
       		                                                        }-> NextPt
 };
 
@@ -385,9 +386,9 @@ M_ServeReturnFrom2 = pcase {
 			6: FH_ServeReturnToPosition6{ball = 6} -> KS_NormalReturnFrom6
 			2: FH_ServeReturnToPosition7{ball = 7} -> KS_NormalReturnFrom7
 			7: FH_ServeReturnToPosition8{ball = 8} -> KS_NormalReturnFrom8
-			2: BH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS} 
+			2: BH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS} 
       		                                                        }-> NextPt
-      		2: FH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS} 
+      		2: FH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS} 
       		                                                        }-> NextPt
 };
 
@@ -400,9 +401,9 @@ T_ServeReturnFrom1 = pcase {
 			1: FH_ServeReturnToPosition6{ball = 6} -> KS_NormalReturnFrom6
 			3: FH_ServeReturnToPosition7{ball = 7} -> KS_NormalReturnFrom7
 			6: FH_ServeReturnToPosition8{ball = 8} -> KS_NormalReturnFrom8
-			4: BH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS} 
+			4: BH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS} 
       		                                                        }-> NextPt
-      		3: FH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = MT} 
+      		3: FH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = MT} 
       		                                                        }-> NextPt
 };
 
@@ -415,9 +416,9 @@ T_ServeReturnFrom2 = pcase {
 			0: FH_ServeReturnToPosition6{ball = 6} -> KS_NormalReturnFrom6
 			0: FH_ServeReturnToPosition7{ball = 7} -> KS_NormalReturnFrom7
 			0: FH_ServeReturnToPosition8{ball = 8} -> KS_NormalReturnFrom8
-			0: FH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS} 
+			0: FH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS} 
       		                                                        }-> NextPt
-      		0: BH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS} 
+      		0: BH_ServeReturnError{ball = 9} -> KSWinPoint{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS} 
       		                                                        }-> NextPt
 };
 
@@ -425,28 +426,28 @@ T_ServeReturnFrom2 = pcase {
 MT_NormalReturnFrom1 = pcase {
 			13: MNormalReturn -> M_NormalReturnFrom1
 			24: TNormalReturn -> T_NormalReturnFrom1
-			8: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS} 
+			8: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS} 
       		                                                        }-> NextPt
 };
 
 MT_NormalReturnFrom2 = pcase {
 			31: MNormalReturn -> M_NormalReturnFrom2
 			8: TNormalReturn -> T_NormalReturnFrom2
-			7: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS} 
+			7: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS} 
       		                                                        }-> NextPt
 };
 
 MT_NormalReturnFrom3 = pcase {
 			20: MNormalReturn -> M_NormalReturnFrom3
 			24: TNormalReturn -> T_NormalReturnFrom3
-			16: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}     		                                                        
+			16: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS}     		                                                        
 																	}-> NextPt
 };
 
 MT_NormalReturnFrom4 = pcase {
 			41: MNormalReturn -> M_NormalReturnFrom4
 			19: TNormalReturn -> T_NormalReturnFrom4
-			11: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS} 
+			11: FailToReturn{ball = 9} -> KSWinPoint{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS} 
       		                                                        }-> NextPt
 };		
 
@@ -459,9 +460,9 @@ M_NormalReturnFrom1 = pcase {
 			0: FH_NormalReturnToPosition6{ball = 6} -> KS_NormalReturnFrom6
 			3: FH_NormalReturnToPosition7{ball = 7} -> KS_NormalReturnFrom7
 			7: FH_NormalReturnToPosition8{ball = 8} -> KS_NormalReturnFrom8                         
-			0: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
+			0: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS}}
 				-> NextPt
-			1: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
+			1: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS}}
 				-> NextPt
 };	
 
@@ -474,9 +475,9 @@ M_NormalReturnFrom2 = pcase {
 			4: FH_NormalReturnToPosition6{ball = 6} -> KS_NormalReturnFrom6
 			1: FH_NormalReturnToPosition7{ball = 7} -> KS_NormalReturnFrom7
 			14: FH_NormalReturnToPosition8{ball = 8} -> KS_NormalReturnFrom8                         
-			3: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
+			3: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS}}
 				-> NextPt
-			2: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
+			2: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS}}
 				-> NextPt
 };
 
@@ -489,9 +490,9 @@ M_NormalReturnFrom3 = pcase {
 			4: FH_NormalReturnToPosition6{ball = 6} -> KS_NormalReturnFrom6
 			3: FH_NormalReturnToPosition7{ball = 7} -> KS_NormalReturnFrom7
 			8: FH_NormalReturnToPosition8{ball = 8} -> KS_NormalReturnFrom8                         
-			0: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
+			0: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS}}
 				-> NextPt
-			4: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
+			4: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS}}
 				-> NextPt
 };	
 
@@ -504,9 +505,9 @@ M_NormalReturnFrom4 = pcase {
 			2: FH_NormalReturnToPosition6{ball = 6} -> KS_NormalReturnFrom6
 			7: FH_NormalReturnToPosition7{ball = 7} -> KS_NormalReturnFrom7
 			6: FH_NormalReturnToPosition8{ball = 8} -> KS_NormalReturnFrom8                         
-			7: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
+			7: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS}}
 				-> NextPt
-			0: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
+			0: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS}}
 				-> NextPt
 };					
 
@@ -519,9 +520,9 @@ T_NormalReturnFrom1 = pcase {
 			1: FH_NormalReturnToPosition6{ball = 6} -> KS_NormalReturnFrom6
 			0: FH_NormalReturnToPosition7{ball = 7} -> KS_NormalReturnFrom7
 			6: FH_NormalReturnToPosition8{ball = 8} -> KS_NormalReturnFrom8                         
-			2: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
+			2: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS}}
 				-> NextPt
-			3: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
+			3: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS}}
 				-> NextPt
 };
 
@@ -534,9 +535,9 @@ T_NormalReturnFrom2 = pcase {
 			0: FH_NormalReturnToPosition6{ball = 6} -> KS_NormalReturnFrom6
 			6: FH_NormalReturnToPosition7{ball = 7} -> KS_NormalReturnFrom7
 			1: FH_NormalReturnToPosition8{ball = 8} -> KS_NormalReturnFrom8                         
-			1: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
+			1: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS}}
 				-> NextPt
-			3: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
+			3: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS}}
 				-> NextPt
 };
 
@@ -549,9 +550,9 @@ T_NormalReturnFrom3 = pcase {
 			3: FH_NormalReturnToPosition6{ball = 6} -> KS_NormalReturnFrom6
 			3: FH_NormalReturnToPosition7{ball = 7} -> KS_NormalReturnFrom7
 			6: FH_NormalReturnToPosition8{ball = 8} -> KS_NormalReturnFrom8                         
-			7: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
+			7: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS}}
 				-> NextPt
-			6: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
+			6: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS}}
 				-> NextPt
 };			
 		
@@ -564,9 +565,9 @@ T_NormalReturnFrom4 = pcase {
 			3: FH_NormalReturnToPosition6{ball = 6} -> KS_NormalReturnFrom6
 			3: FH_NormalReturnToPosition7{ball = 7} -> KS_NormalReturnFrom7
 			2: FH_NormalReturnToPosition8{ball = 8} -> KS_NormalReturnFrom8                         
-			1: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
+			1: BH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS}}
 				-> NextPt
-			1: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if (KSscore >= winningScore && KSscore >= (MTscore + pointLead)) {won = KS}}
+			1: FH_NormalReturn_Out{ball = 9} -> MTOut{KSscore++; if ((KSscore >= winningScore && KSscore >= (MTscore + pointLead)) || (KSscore == scoreCap)) {won = KS}}
 				-> NextPt
 };
 


### PR DESCRIPTION
Tried to implement the real-world tennis game scoring system but it crashes PAT every time.

To fix this, I tried to remove the score logic from all the MT code while leaving it for KS code and it works.
However, as soon as you add the logic back to one line of MT code (in particular, adding it back to a normalReturn line of code), PAT will run too long and crash.

If anyone wants to test it, you can pull the PointToGame.pcsp file from the `change-scoring-system` branch and try to run verification in PAT.